### PR TITLE
ci(workflow): create workflow for close-stale-issue

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,22 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-label: "stale"
+          exempt-issue-labels: "linear,📍 roadmap,🙌 good-first-issue,🙋‍♂️ help-wanted"
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days."
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days."
+          days-before-stale: 30
+          days-before-close: 7


### PR DESCRIPTION
Because

- We have to create a workflow for automatically closing issues/PRs that have been open 30 days with no activity

This commit

- create workflow for close-stale-issue
